### PR TITLE
Force read_reply to be atomic

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -133,19 +133,24 @@ module Make(IO : S.IO) = struct
     loop [] num_bulk
 
   and read_reply in_ch =
-    IO.input_char in_ch >>= function
-      | '+' ->
-          read_line in_ch >>= fun s -> IO.return (`Status s)
-      | '-' ->
-          read_line in_ch >>= fun s -> IO.return (`Error s)
-      | ':' ->
-          read_integer in_ch
-      | '$' ->
-          read_bulk in_ch
-      | '*' ->
-          read_multibulk in_ch
-      | c ->
-          IO.fail (Unrecognized ("Unexpected char in reply", Char.escaped c))
+    IO.atomic
+      (fun ch ->
+       IO.input_char ch >>= fun c ->
+       match c with
+       | '+' ->
+          read_line ch >>= fun s -> IO.return (`Status s)
+       | '-' ->
+          read_line ch >>= fun s -> IO.return (`Error s)
+       | ':' ->
+          read_integer ch
+       | '$' ->
+          read_bulk ch
+       | '*' ->
+          read_multibulk ch
+       | c ->
+          IO.fail (Unrecognized ("Unexpected char in replyyyy", Char.escaped c))
+      )
+      in_ch
 
   let read_reply_exn in_ch =
     read_reply in_ch >>= function

--- a/src/s.mli
+++ b/src/s.mli
@@ -19,6 +19,7 @@ module type IO = sig
   val return : 'a -> 'a t
   val fail : exn -> 'a t
   val run : 'a t -> 'a
+  val atomic : (in_channel -> 'a t) -> in_channel -> 'a t
 
   val in_channel_of_descr : fd -> in_channel
   val out_channel_of_descr : fd -> out_channel

--- a/src_lwt/redis_lwt.ml
+++ b/src_lwt/redis_lwt.ml
@@ -15,6 +15,7 @@ module IO = struct
   let return = Lwt.return
   let fail = Lwt.fail
   let run = Lwt_main.run
+  let atomic = Lwt_io.atomic
 
   let connect host port =
     let port = string_of_int port in

--- a/src_sync/redis_sync.ml
+++ b/src_sync/redis_sync.ml
@@ -19,6 +19,7 @@ module IO = struct
   let return a = a
   let fail e = raise e
   let run a = a
+  let atomic f ch = f ch
 
   let connect host port =
     let port = string_of_int port in


### PR DESCRIPTION
This fixes #40. Previously if you send multiple commands in parallel, reads may conflict with each and be corrupted. We need to make reading each reply atomic to make sure they don't step on each other.