### PR TITLE
Simplify build step in opam

### DIFF
--- a/redis-lwt.opam
+++ b/redis-lwt.opam
@@ -11,8 +11,7 @@ license: "BSD3"
 tags: []
 dev-repo: "https://github.com/0xffea/ocaml-redis.git"
 build: [
-  ["jbuilder" "build" "--only-packages" "redis-lwt" "--root" "."
-   "-j" jobs "@install"]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "jbuilder" {build}

--- a/redis-sync.opam
+++ b/redis-sync.opam
@@ -11,8 +11,7 @@ license: "BSD3"
 tags: []
 dev-repo: "https://github.com/0xffea/ocaml-redis.git"
 build: [
-  ["jbuilder" "build" "--only-packages" "redis-sync" "--root" "."
-   "-j" jobs "@install"]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "jbuilder" {build}

--- a/redis.opam
+++ b/redis.opam
@@ -11,8 +11,7 @@ license: "BSD3"
 tags: []
 dev-repo: "https://github.com/0xffea/ocaml-redis.git"
 build: [
-  ["jbuilder" "build" "--only-packages" "redis" "--root" "."
-   "-j" jobs "@install"]
+  ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "jbuilder" {build}


### PR DESCRIPTION
Uses the "generic" build command that will work for all jbuilder projects
regardless of name. Functionally, this is equivalent to what was there
previously.