### PR TITLE
Enable safe-string support

### DIFF
--- a/examples/jbuild
+++ b/examples/jbuild
@@ -2,4 +2,5 @@
 
 (executables
  ((libraries (threads core redis.lwt redis.syc))
+  (flags (:standard -safe-string))
   (names (examples))))

--- a/src/client.ml
+++ b/src/client.ml
@@ -107,6 +107,7 @@ module Common(IO: S.IO) = struct
     IO.really_input in_ch line 0 length >>= fun () ->
     IO.input_char in_ch >>= fun c1 ->
     IO.input_char in_ch >>= fun c2 ->
+    let line = Bytes.to_string line in
     match c1, c2 with
       | '\r', '\n' -> IO.return line
       | _          -> IO.fail (Unrecognized ("Expected terminator", line))
@@ -509,11 +510,11 @@ module type Mode = sig
   end
 
   val write : IO.out_channel -> string list -> unit IO.t
-  val read_fixed_line : int -> IO.in_channel -> bytes IO.t
+  val read_fixed_line : int -> IO.in_channel -> string IO.t
   val read_line : IO.in_channel -> string IO.t
   val classify_error : string -> [> `Ask of redirection | `Error of string | `Moved of redirection ] IO.t
   val read_integer : IO.in_channel -> [> `Int of int | `Int64 of int64 ] IO.t
-  val read_bulk : IO.in_channel -> [> `Bulk of bytes option ] IO.t
+  val read_bulk : IO.in_channel -> [> `Bulk of string option ] IO.t
   val interleave : ('a * 'a) list -> 'a list
   val deinterleave : 'a list -> ('a * 'a) list
   val return_bulk : reply -> string option IO.t
@@ -550,13 +551,13 @@ module type Mode = sig
   val read_reply_exn :
     IO.in_channel ->
     [> `Ask of redirection
-    | `Bulk of bytes option
+    | `Bulk of string option
     | `Int of int
     | `Int64 of int64
     | `Moved of redirection
     | `Multibulk of
          [ `Ask of redirection
-         | `Bulk of bytes option
+         | `Bulk of string option
          | `Error of string
          | `Int of int
          | `Int64 of int64
@@ -569,12 +570,12 @@ module type Mode = sig
   val send_request :
     connection ->
     string list ->
-    [> `Bulk of bytes option
+    [> `Bulk of string option
     | `Int of int
     | `Int64 of int64
     | `Multibulk of
          [ `Ask of redirection
-         | `Bulk of bytes option
+         | `Bulk of string option
          | `Error of string
          | `Int of int
          | `Int64 of int64

--- a/src/jbuild
+++ b/src/jbuild
@@ -3,4 +3,5 @@
 (library
  ((name redis)
   (public_name redis)
+  (flags (:standard -safe-string))
   (libraries (bytes re.str uuidm))))

--- a/src/s.ml
+++ b/src/s.ml
@@ -24,7 +24,7 @@ module type IO = sig
   val in_channel_of_descr : fd -> in_channel
   val out_channel_of_descr : fd -> out_channel
   val input_char : in_channel -> char t
-  val really_input : in_channel -> string -> int -> int -> unit t
+  val really_input : in_channel -> bytes -> int -> int -> unit t
   val output_string : out_channel -> string -> unit t
   val flush : out_channel -> unit t
 

--- a/src_lwt/jbuild
+++ b/src_lwt/jbuild
@@ -4,4 +4,5 @@
  ((name redis_lwt)
   (wrapped false)
   (public_name redis-lwt)
+  (flags (:standard -safe-string))
   (libraries (redis lwt.unix lwt))))

--- a/src_sync/jbuild
+++ b/src_sync/jbuild
@@ -4,4 +4,5 @@
  ((name redis_sync)
   (wrapped false)
   (public_name redis-sync)
+  (flags (:standard -safe-string))
   (libraries (redis))))

--- a/test/jbuild
+++ b/test/jbuild
@@ -3,10 +3,12 @@
 (library
  ((name redis_test)
   (modules test)
+  (flags (:standard -safe-string))
   (libraries (redis oUnit))))
 
 (executables
  ((libraries (redis_test redis_sync redis_lwt))
+  (flags (:standard -safe-string))
   (names (test_sync test_lwt))))
 
 (alias


### PR DESCRIPTION
The interface needed a bit of change to be compilable using OCaml 4.06.0 or any other compiler versions with safe-string enabled.
Let me know if the changes are ok or not.