### PR TITLE
Don't use IO.ignore

### DIFF
--- a/src/cache.ml
+++ b/src/cache.ml
@@ -8,12 +8,11 @@ module Make(IO : S.IO)(Client : S.Client with module IO = IO)(Params : S.Cache_p
   let set r key data =
     let key = Params.cache_key key in
     let data = Params.string_of_data data in
-    Client.set r key data >>= fun _ ->
-    IO.return (Utils.Option.may
-      (fun cache_expiration ->
-        IO.ignore_result (Client.expire r key cache_expiration)
-      )
-      Params.cache_expiration)
+    Client.set r key data >>= fun res ->
+    match Params.cache_expiration with 
+    | None -> IO.return () 
+    | Some cache_expiration -> 
+        Client.expire r key cache_expiration >>= (fun _ -> IO.return ())
 
   let get r key =
     let key = Params.cache_key key in


### PR DESCRIPTION
As it is deprecated.
Moreover, we want to wait for the completion of expire. Otherwise, if say you call this within `with_connection`, it doesn't work