### PR TITLE
Add commands for popping elements off sorted sets

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -1630,7 +1630,7 @@ module MakeClient(Mode: Mode) = struct
   (** Remove and return the member with the lowest/highest scores in a sorted set, or block until one is available. *)
   let (bzpopmin, bzpopmax) =
     let bzpop op connection keys timeout =
-      let command = List.concat [[op]; keys; [string_of_int timeout]] in
+      let command = List.concat [[op]; keys; [string_of_float timeout]] in
       send_request connection command >>= fun reply ->
       return_bulk_multibulk reply >>= function
       | [] -> IO.return None

--- a/src/s.ml
+++ b/src/s.ml
@@ -545,10 +545,10 @@ module type Client = sig
   val zpopmax : connection -> string -> int -> (string * float) list IO.t
 
   (** Remove and return the member with the lowest score in a sorted set, or block until one is available. *)
-  val bzpopmin : connection -> string list -> int -> (string * string * float) option IO.t
+  val bzpopmin : connection -> string list -> float -> (string * string * float) option IO.t
 
   (** Remove and return the member with the highest score in a sorted set, or block until one is available. *)
-  val bzpopmax : connection -> string list -> int -> (string * string * float) option IO.t
+  val bzpopmax : connection -> string list -> float -> (string * string * float) option IO.t
 
   (** {2 Stream commands}
 

--- a/src/s.ml
+++ b/src/s.ml
@@ -538,6 +538,12 @@ module type Client = sig
   (** Returns the reversed rank of member in the sorted set stored at key. *)
   val zrevrank : connection -> string -> string -> int option IO.t
 
+  (** Removes and returns one or more members with the lowest scores in a sorted set. *)
+  val zpopmin : connection -> string -> int -> (string * float) list IO.t
+
+  (** Remove and return one or more members with the highest scores in a sorted set. *)
+  val zpopmax : connection -> string -> int -> (string * float) list IO.t
+
   (** {2 Stream commands}
 
       For redis >= 5. We only support a subset of the commands for now. *)

--- a/src/s.ml
+++ b/src/s.ml
@@ -544,6 +544,12 @@ module type Client = sig
   (** Remove and return one or more members with the highest scores in a sorted set. *)
   val zpopmax : connection -> string -> int -> (string * float) list IO.t
 
+  (** Remove and return the member with the lowest score in a sorted set, or block until one is available. *)
+  val bzpopmin : connection -> string list -> int -> (string * string * float) option IO.t
+
+  (** Remove and return the member with the highest score in a sorted set, or block until one is available. *)
+  val bzpopmax : connection -> string list -> int -> (string * string * float) option IO.t
+
   (** {2 Stream commands}
 
       For redis >= 5. We only support a subset of the commands for now. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -531,10 +531,12 @@ end = struct
       io_assert "zpopmax: items (e, d)" ((=) ["e", 5.; "d", 4.])) >>= fun () ->
 
     test_case (fun key ->
-      Client.bzpopmin conn [ key ] 1 >>=
+      Client.bzpopmin conn [ key ] 1. >>=
       io_assert "bzpopmin: item (a)" ((=) (Some (key, "a", 1.))) >>= fun () ->
-      Client.bzpopmax conn [ key ] 1 >>=
-      io_assert "bzpopmax: item (e)" ((=) (Some (key, "e", 5.))))
+      Client.bzpopmax conn [ key ] 1. >>=
+      io_assert "bzpopmax: item (e)" ((=) (Some (key, "e", 5.))) >>= fun () ->
+      Client.bzpopmax conn [ redis_string_bucket () ] 1e-2 >>=
+      io_assert "bzpopmax: nothing" ((=) None))
 
   let test_case_stream conn =
     let key = redis_string_bucket() in

--- a/test/test.ml
+++ b/test/test.ml
@@ -517,6 +517,14 @@ end = struct
     Client.zremrangebylex conn key NegInfinity PosInfinity >>=
     io_assert "removed wrong number of items" ((=) 2)
 
+  let test_case_sorted_set_pop conn =
+    let key = redis_string_bucket () in
+    Client.zadd conn key [1., "a"; 2., "b"; 3., "c"; 4., "d"; 5., "e"] >>= fun _ ->
+    Client.zpopmin conn key 2 >>=
+    io_assert "zpopmin: items (a, b)" (fun l -> l = ["a", 1.; "b", 2.]) >>= fun _ ->
+    Client.zpopmax conn key 2 >>=
+    io_assert "zpopmax: items (e, d)" (fun l -> l = ["e", 5.; "d", 4.])
+
   let test_case_stream conn =
     let key = redis_string_bucket() in
     Client.xadd conn key ["x", "1"; "y", "2"] >>= fun id1 ->
@@ -655,6 +663,7 @@ end = struct
         "test_case_hyper_log_log" >:: (bracket test_case_hyper_log_log);
         "test_case_sorted_set" >:: (bracket test_case_sorted_set);
         "test_case_sorted_set_remove" >:: (bracket test_case_sorted_set_remove);
+        "test_case_sorted_set_pop" >:: (bracket test_case_sorted_set_pop);
         "test_stream" >:: bracket test_case_stream;
         "test_stream_xread" >:: bracket (test_case_stream_xread ~spec:redis_specs.no_auth);
       ]


### PR DESCRIPTION
This PR adds these commands to the client:

* [ZPOPMIN](https://redis.io/commands/zpopmin)
* [ZPOPMAX](https://redis.io/commands/zpopmax)
* [BZPOPMIN](https://redis.io/commands/bzpopmin)
* [BZPOPMAX](https://redis.io/commands/bzpopmax)