### PR TITLE
Expose send_request to use Redis extensions

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -802,6 +802,8 @@ module MakeClient(Mode: Mode) = struct
     let command = [ "SELECT"; index ] in
     send_request connection command >>= return_ok_status
 
+  let send_custom_request = send_request
+  
   (** SENTINEL commands *)
   let sentinel_masters connection =
     let command = [ "SENTINEL"; "masters"] in

--- a/src/s.ml
+++ b/src/s.ml
@@ -126,7 +126,7 @@ module type Client = sig
   (** Authenticate to server. *)
   val auth : connection -> string -> unit IO.t
 
-  (** Sends a custom request to the Redis server. Example: [ send_request connection ["set"; "foo"; "bar"] ] *)
+  (** Sends a custom request to the Redis server. Example: [ send_request connection ["set"; "foo"; "bar"] ] @since 0.6*)
   val send_request : connection -> string list -> reply IO.t
 
   (** Authenticate to server with username and password. *)

--- a/src/s.ml
+++ b/src/s.ml
@@ -127,7 +127,7 @@ module type Client = sig
   val auth : connection -> string -> unit IO.t
 
   (** Sends a custom request to the Redis server. Example: [ send_request connection ["set"; "foo"; "bar"] ] @since 0.6*)
-  val send_request : connection -> string list -> reply IO.t
+  val send_custom_request : connection -> string list -> reply IO.t
 
   (** Authenticate to server with username and password. *)
   val auth_acl : connection -> string -> string -> unit IO.t

--- a/src/s.ml
+++ b/src/s.ml
@@ -126,6 +126,9 @@ module type Client = sig
   (** Authenticate to server. *)
   val auth : connection -> string -> unit IO.t
 
+  (** Sends a custom request to the Redis server. Example: [ send_request connection ["set"; "foo"; "bar"] ] *)
+  val send_request : connection -> string list -> reply IO.t
+
   (** Authenticate to server with username and password. *)
   val auth_acl : connection -> string -> string -> unit IO.t
 


### PR DESCRIPTION
Exposed send_request so the user can use Redis extensions, run arbitrary commands, and use the entire [Redis stack](https://redis.io/docs/stack/)