### PR TITLE
Fix out of order arguments on network with lwt

### DIFF
--- a/src/client.ml
+++ b/src/client.ml
@@ -117,7 +117,7 @@ module Common(IO: S.IO) = struct
     let num_args = List.length args in
     IO.output_string out_ch (Printf.sprintf "*%d" num_args) >>= fun () ->
     IO.output_string out_ch "\r\n" >>= fun () ->
-    IO.iter
+    IO.iter_serial
       (fun arg ->
          let length = String.length arg in
          IO.output_string out_ch (Printf.sprintf "$%d" length) >>= fun () ->
@@ -803,7 +803,7 @@ module MakeClient(Mode: Mode) = struct
     send_request connection command >>= return_ok_status
 
   let send_custom_request = send_request
-  
+
   (** SENTINEL commands *)
   let sentinel_masters connection =
     let command = [ "SENTINEL"; "masters"] in


### PR DESCRIPTION
We discovered a bug related to how the different argument of the redis protocol are written to the out channel. It appears that sometimes (especially visible when there's a high load or with large values) some arguments are written in the wrong order.

The starting point to reproduce is something like this
```
# let s = String.init 512_345_678 (fun i -> char_of_int (97 + (i mod 26)));;
val s : string =
  "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm"... (* string length 512345678; truncated *)
# Redis.set conn ~px:3600000 "key" s;;
```

It generates an exception
```
Redis.Client.Common(IO).Redis_error("ERR Protocol error: expected '$', got '0'")
```

And an error in redis-server's logs
```
1964:M 25 Jul 2023 07:03:18.461 - Protocol error (expected $ but got something else) from client: id=85607 addr=127.0.0.1:41152 fd=2535 name= age=17353 idle=0 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=20 qbuf-free=2337462 argv-mem=2337535 obl=44 oll=0 omem=0 tot-mem=4979503 events=r cmd=get user=default. Query buffer during protocol error: '0000....'
```

After some investigation with tcpdump, I found something weird
```
reading from file redis.pcap, link-type EN10MB (Ethernet), snapshot length 262144
E.	.}.@.@..X..............a..`K............
........vwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz$2$7


PX3600000


```

Shortening and keeping only the tail to help with readability and simplicity, we can see that what is send to redis isn't what we expected. We have
```
stuvwxyz$2$7


PX3600000
```

While we want
```
stuvwxyz
$2
PX
$7
3600000
```

We can see that the `$2`, `$7`, and `\r\n` are not sent in the order that is required by the redis protocol. The bug comes from the fact that the `IO.iter` function that is used over the list of arguments to send is actually... `Lwt_list.iter_p`, which obviously won't work correctly here. The fix is to use `IO.iter_serial`

https://github.com/0xffea/ocaml-redis/blob/508685dd28cd8759f706f334f064d5bfd2a3085d/src_lwt/redis_lwt.ml#L50

I'd argue that `IO.iter`/`IO.map` being parallel by default is really surprising. But this another discussion.

This work is paid for by Ahrefs.