### PR TITLE
Support connections to Unix domain sockets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Start containers
       run: docker-compose up -d
       if: ${{ matrix.os == 'ubuntu-latest'}}
-    - run: opam exec -- dune runtest
+    - run: OCAML_REDIS_TEST_SOCKET=$PWD/socket/redis.sock opam exec -- dune runtest
       if: ${{ matrix.os == 'ubuntu-latest'}}
     - name: Stop containers
       run: docker-compose down

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@
 .merlin
 *.install
 *.exe
-
 /result*
+/socket/redis.sock

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+export OCAML_REDIS_TEST_SOCKET=$(CURDIR)/socket/redis.sock
 
 DOCKER_COMPOSE?=docker-compose
 all: build test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
+DOCKER_COMPOSE ?= docker-compose
+
 export OCAML_REDIS_TEST_SOCKET=$(CURDIR)/socket/redis.sock
 
-DOCKER_COMPOSE?=docker-compose
 all: build test
 
 build:
@@ -8,7 +9,7 @@ build:
 
 test:
 	@$(DOCKER_COMPOSE) up -d
-	@(dune runtest --force --no-buffer; EXIT_CODE="$$?"; docker-compose down; exit $$EXIT_CODE)
+	@(dune runtest --force --no-buffer; EXIT_CODE="$$?"; $(DOCKER_COMPOSE) down; exit $$EXIT_CODE)
 
 clean:
 	@dune clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - "63793:6379"
   unix_socket:
     image: "redis:6-alpine"
-    command: redis-server --unixsocket /socket/redis.sock --unixsocketperm 777
+    command: |
+      sh -xc "chmod 777 /socket && redis-server --unixsocket /socket/redis.sock --unixsocketperm 777"
     volumes:
       - ./socket:/socket

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,8 @@ services:
     build: ./test/docker/with_acl
     ports:
       - "63793:6379"
+  unix_socket:
+    image: "redis:6-alpine"
+    command: redis-server --unixsocket /socket/redis.sock --unixsocketperm 777
+    volumes:
+      - ./socket:/socket

--- a/src/client.ml
+++ b/src/client.ml
@@ -359,7 +359,8 @@ module Common(IO: S.IO) = struct
         | ai::_ -> IO.return ai
         | [] -> IO.fail (Failure "Could not resolve redis host!")
     in
-    addr_info >>= IO.connect >>= fun fd ->
+    addr_info >>= fun {ai_family; ai_addr; _} ->
+    IO.connect ai_family ai_addr >>= fun fd ->
     let in_ch = IO.in_channel_of_descr fd in
     IO.return
       { fd = fd;

--- a/src/client.ml
+++ b/src/client.ml
@@ -53,6 +53,8 @@ module Common(IO: S.IO) = struct
 
   let connection_spec ?(port=6379) host = {host; port}
 
+  let connection_spec_unix_socket socket = {host = socket; port = 0}
+
   module SlotMap = Map.Make(struct
       type t = int
       let compare = Stdlib.compare
@@ -500,6 +502,7 @@ module type Mode = sig
   }
 
   val connection_spec : ?port:int -> string -> connection_spec
+  val connection_spec_unix_socket : string -> connection_spec
 
   module SlotMap : Map.S with type key = int
   module ConnectionSpecMap : Map.S with type key = connection_spec

--- a/src/client.ml
+++ b/src/client.ml
@@ -12,6 +12,7 @@ module Common(IO: S.IO) = struct
   module IO = IO
 
   let (>>=) = IO.(>>=)
+  let (>|=) = IO.(>|=)
 
   type redirection = {
     slot: int;
@@ -362,8 +363,7 @@ module Common(IO: S.IO) = struct
            | ai::_ -> IO.return ai
            | [] -> IO.fail (Failure "Could not resolve redis host!")
        in
-       addr_info >>= fun {ai_family; ai_addr; _} ->
-       IO.return (ai_family, ai_addr))
+       addr_info >|= fun {ai_family; ai_addr; _} -> (ai_family, ai_addr))
     >>= fun (ai_family, ai_addr) ->
     IO.connect ai_family ai_addr >>= fun fd ->
     let in_ch = IO.in_channel_of_descr fd in

--- a/src/s.ml
+++ b/src/s.ml
@@ -8,7 +8,8 @@ module type IO = sig
   type 'a stream
   type stream_count
 
-  val connect : string -> int -> fd t
+  val getaddrinfo : string -> string -> Unix.getaddrinfo_option list -> Unix.addr_info list t
+  val connect : Unix.addr_info -> fd t
   val close : fd -> unit t
   val sleep : float -> unit t
 

--- a/src/s.ml
+++ b/src/s.ml
@@ -9,7 +9,7 @@ module type IO = sig
   type stream_count
 
   val getaddrinfo : string -> string -> Unix.getaddrinfo_option list -> Unix.addr_info list t
-  val connect : Unix.addr_info -> fd t
+  val connect : Unix.socket_domain -> Unix.sockaddr -> fd t
   val close : fd -> unit t
   val sleep : float -> unit t
 

--- a/src/s.ml
+++ b/src/s.ml
@@ -96,9 +96,10 @@ module type Client = sig
 
   val connection_spec : ?port:int -> string -> connection_spec
   (** Create a connection spec with the given host.
-      Specify a path and port 0 to use unix domain sockets.
-      @param port Port to connect to (default [6379])
+      @param port port to connect to (default [6379])
       @since 0.5 *)
+
+  val connection_spec_unix_socket : string -> connection_spec
 
   module SlotMap : Map.S with type key = int
   module ConnectionSpecMap : Map.S with type key = connection_spec

--- a/src/s.ml
+++ b/src/s.ml
@@ -96,7 +96,8 @@ module type Client = sig
 
   val connection_spec : ?port:int -> string -> connection_spec
   (** Create a connection spec with the given host.
-      @param port port to connect to (default [6379])
+      Specify a path and port 0 to use unix domain sockets.
+      @param port Port to connect to (default [6379])
       @since 0.5 *)
 
   module SlotMap : Map.S with type key = int

--- a/src_lwt/redis_lwt.ml
+++ b/src_lwt/redis_lwt.ml
@@ -20,10 +20,10 @@ module IO = struct
 
   let getaddrinfo = Lwt_unix.getaddrinfo
 
-  let connect addr_info =
-    let fd = Lwt_unix.socket addr_info.Lwt_unix.ai_family Lwt_unix.SOCK_STREAM 0 in
+  let connect family addr =
+    let fd = Lwt_unix.socket family Lwt_unix.SOCK_STREAM 0 in
     let do_connect () =
-      Lwt_unix.connect fd addr_info.Lwt_unix.ai_addr >>= fun () ->
+      Lwt_unix.connect fd addr >>= fun () ->
       return fd
     in
     catch do_connect (fun exn -> Lwt_unix.close fd >>= fun () -> fail exn)

--- a/src_lwt/redis_lwt.ml
+++ b/src_lwt/redis_lwt.ml
@@ -18,18 +18,9 @@ module IO = struct
   let run = Lwt_main.run
   let atomic = Lwt_io.atomic
 
-  let connect host port =
-    let port = string_of_int port in
-    let addr_info =
-      let open Lwt_unix in
-      getaddrinfo host port [AI_FAMILY PF_INET] >>= function
-      | ai::_ -> return ai
-      | [] ->
-        getaddrinfo host port [AI_FAMILY PF_INET6] >>= function
-        | ai::_ -> return ai
-        | [] -> Lwt.fail_with "Could not resolve redis host!"
-    in
-    addr_info >>= fun addr_info ->
+  let getaddrinfo = Lwt_unix.getaddrinfo
+
+  let connect addr_info =
     let fd = Lwt_unix.socket addr_info.Lwt_unix.ai_family Lwt_unix.SOCK_STREAM 0 in
     let do_connect () =
       Lwt_unix.connect fd addr_info.Lwt_unix.ai_addr >>= fun () ->

--- a/src_sync/redis_sync.ml
+++ b/src_sync/redis_sync.ml
@@ -20,10 +20,10 @@ module IO = struct
 
   let getaddrinfo = Unix.getaddrinfo
 
-  let connect addr_info =
-    let fd = Unix.socket addr_info.Unix.ai_family Unix.SOCK_STREAM 0 in
+  let connect family addr =
+    let fd = Unix.socket family Unix.SOCK_STREAM 0 in
     try
-      Unix.connect fd addr_info.Unix.ai_addr; fd
+      Unix.connect fd addr; fd
     with
       exn -> Unix.close fd; raise exn
 

--- a/src_sync/redis_sync.ml
+++ b/src_sync/redis_sync.ml
@@ -18,17 +18,9 @@ module IO = struct
   let run a = a
   let atomic f ch = f ch
 
-  let connect host port =
-    let port = string_of_int port in
-    let addr_info =
-      let open Unix in
-      match getaddrinfo host port [AI_FAMILY PF_INET] with
-      | ai::_ -> ai
-      | [] ->
-        match getaddrinfo host port [AI_FAMILY PF_INET6] with
-        | ai::_ -> ai
-        | []    -> failwith "Could not resolve redis host!"
-    in
+  let getaddrinfo = Unix.getaddrinfo
+
+  let connect addr_info =
     let fd = Unix.socket addr_info.Unix.ai_family Unix.SOCK_STREAM 0 in
     try
       Unix.connect fd addr_info.Unix.ai_addr; fd

--- a/test/test.ml
+++ b/test/test.ml
@@ -10,7 +10,7 @@ let redis_test_socket () =
   try
     Sys.getenv("OCAML_REDIS_TEST_SOCKET")
   with Not_found ->
-    "socket/redis.sock"
+    failwith "Environment variable OCAML_REDIS_TEST_SOCKET must be set"
 
 let redis_test_port = 63791
 let redis_test_port_with_auth = 63792

--- a/test/test.ml
+++ b/test/test.ml
@@ -63,10 +63,10 @@ end = struct
 
   let redis_specs : containers =
     {
-      no_auth = Client.({host=redis_test_host (); port=redis_test_port });
-      with_auth = Client.({host=redis_test_host (); port=redis_test_port_with_auth }); 
-      with_acl = Client.({host=redis_test_host (); port=redis_test_port_with_acl });
-      unix_socket = Client.({host=redis_test_socket (); port=0 });
+      no_auth = Client.connection_spec ~port:redis_test_port (redis_test_host ());
+      with_auth = Client.connection_spec ~port:redis_test_port_with_auth (redis_test_host ());
+      with_acl = Client.connection_spec ~port:redis_test_port_with_acl (redis_test_host ());
+      unix_socket = Client.connection_spec_unix_socket (redis_test_socket ());
     }
 
   let redis_spec_no_auth = redis_specs.no_auth

--- a/test/test.ml
+++ b/test/test.ml
@@ -6,6 +6,12 @@ let redis_test_host () =
   with Not_found ->
     "127.0.0.1"
 
+let redis_test_socket () =
+  try
+    Sys.getenv("OCAML_REDIS_TEST_SOCKET")
+  with Not_found ->
+    "socket/redis.sock"
+
 let redis_test_port = 63791
 let redis_test_port_with_auth = 63792
 let redis_test_port_with_acl = 63793
@@ -52,6 +58,7 @@ end = struct
     no_auth : Client.connection_spec;
     with_auth : Client.connection_spec;
     with_acl : Client.connection_spec;
+    unix_socket : Client.connection_spec;
   }
 
   let redis_specs : containers =
@@ -59,6 +66,7 @@ end = struct
       no_auth = Client.({host=redis_test_host (); port=redis_test_port });
       with_auth = Client.({host=redis_test_host (); port=redis_test_port_with_auth }); 
       with_acl = Client.({host=redis_test_host (); port=redis_test_port_with_acl });
+      unix_socket = Client.({host=redis_test_socket (); port=0 });
     }
 
   let redis_spec_no_auth = redis_specs.no_auth
@@ -661,6 +669,7 @@ end = struct
         "test_case_auth" >:: (bracket ~spec:redis_specs.with_auth test_case_auth);
         "test_case_acl" >:: (bracket ~spec:redis_specs.with_acl test_case_acl);
         "test_case_ping" >:: (bracket test_case_ping);
+        "test_case_unix_socket" >:: (bracket ~spec:redis_specs.unix_socket test_case_ping);
         "test_case_echo" >:: (bracket test_case_echo);
         "test_case_info" >:: (bracket test_case_info);
         "test_case_keys" >:: (bracket test_case_keys);


### PR DESCRIPTION
It's not currently possible to connect to a Redis server that uses Unix domain sockets.

Using Unix domain sockets is handy because it allows using filesystem permissions to control access, and because there's no need to worry about conflicting ports.

This PR introduces support for Unix domain sockets by setting the socket path in the `host` and setting `port` to `0`.

I've taken this approach instead of extending the `connection_spec` or turning it into a variant type because I suspect a lot of code uses `connection_spec` directly and this would be incompatible.

(I think it would be ideal if we supported a single string (`redis://` URL) to specify connection information, as this makes managing client configuration a lot easier and allows extending supported connection types and options without having to change the code that uses this library. But I think that's for another day.)